### PR TITLE
#164 Deleted all information related to the element conditions

### DIFF
--- a/CDC_1.2.2_PROFILE/cdc_122_profile.xml
+++ b/CDC_1.2.2_PROFILE/cdc_122_profile.xml
@@ -1183,41 +1183,6 @@ ________________________________________________________________________________
         </pr:Instructions>
     </pr:Used>
     <!--****************************************************************************************-->
-    <!--ACCESS CATEGORY - OPEN OR RESTRICTED-->
-    <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions" isRequired="true">
-        <r:Description>
-            <r:Content>Required: Mandatory</r:Content>
-            <r:Content>ElementType: Content element</r:Content>
-            <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: Controlled description of the data access (open access vs. restricted access).
-                CDC will use the same Access Rights vocabulary as OpenAIRE.
-                The name of the vocabulary is “info:eu-repo-Access-Terms vocabulary” - see
-                http://purl.org/eu-repo/semantics/#info-eu-repo-AccessRights
-                Only the codes “restrictedAccess” and “openAccess” will be used.</r:Content>
-            <r:Content>CDC_UI_Label: Open/Closed</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-    </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions/@elementVersion"
-        defaultValue="info:eu-repo-Access-Terms vocabulary" fixedValue="true" isRequired="false">
-        <r:Description>
-            <r:Content>Required: Mandatory if 'conditions' element is present</r:Content>
-            <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Always 'info:eu-repo-Access-Terms vocabulary'.</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-        <pr:Instructions>
-            <r:Content>
-                <![CDATA[
-                <Constraints>
-                    <MandatoryNodeIfParentPresentConstraint/>
-                </Constraints>
-                ]]>
-            </r:Content>
-        </pr:Instructions>
-    </pr:Used>
-    <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
     <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">

--- a/CDC_1.2.2_PROFILE/cdc_122_profile_mono.xml
+++ b/CDC_1.2.2_PROFILE/cdc_122_profile_mono.xml
@@ -882,41 +882,6 @@ ________________________________________________________________________________
         </pr:Instructions>
     </pr:Used>
     <!--****************************************************************************************-->
-    <!--ACCESS CATEGORY - OPEN OR RESTRICTED-->
-    <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions" isRequired="true">
-        <r:Description>
-            <r:Content>Required: Mandatory</r:Content>
-            <r:Content>ElementType: Content element</r:Content>
-            <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: Controlled description of the data access (open access vs. restricted access).
-                CDC will use the same Access Rights vocabulary as OpenAIRE.
-                The name of the vocabulary is “info:eu-repo-Access-Terms vocabulary” - see
-                http://purl.org/eu-repo/semantics/#info-eu-repo-AccessRights
-                Only the codes “restrictedAccess” and “openAccess” will be used.</r:Content>
-            <r:Content>CDC_UI_Label: Open/Closed</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-    </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions/@elementVersion"
-        defaultValue="info:eu-repo-Access-Terms vocabulary" fixedValue="true" isRequired="false">
-        <r:Description>
-            <r:Content>Required: Mandatory if 'conditions' element is present</r:Content>
-            <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Always 'info:eu-repo-Access-Terms vocabulary'.</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-        <pr:Instructions>
-            <r:Content>
-                <![CDATA[
-                <Constraints>
-                    <MandatoryNodeIfParentPresentConstraint/>
-                </Constraints>
-                ]]>
-            </r:Content>
-        </pr:Instructions>
-    </pr:Used>
-    <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
     <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">

--- a/CDC_2.5_PROFILE/cdc25_profile.xml
+++ b/CDC_2.5_PROFILE/cdc25_profile.xml
@@ -1203,41 +1203,6 @@ ________________________________________________________________________________
         </pr:Instructions>
     </pr:Used>
     <!--****************************************************************************************-->
-    <!--ACCESS CATEGORY - OPEN OR RESTRICTED-->
-    <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions" isRequired="true">
-        <r:Description>
-            <r:Content>Required: Mandatory</r:Content>
-            <r:Content>ElementType: Content element</r:Content>
-            <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: Controlled description of the data access (open access vs. restricted access).
-                CDC will use the same Access Rights vocabulary as OpenAIRE.
-                The name of the vocabulary is “info:eu-repo-Access-Terms vocabulary” - see
-                http://purl.org/eu-repo/semantics/#info-eu-repo-AccessRights
-                Only the codes “restrictedAccess” and “openAccess” will be used.</r:Content>
-            <r:Content>CDC_UI_Label: Open/Closed</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-    </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions/@elementVersion"
-        defaultValue="info:eu-repo-Access-Terms vocabulary" fixedValue="true" isRequired="false">
-        <r:Description>
-            <r:Content>Required: Mandatory if 'conditions' element is present</r:Content>
-            <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Always 'info:eu-repo-Access-Terms vocabulary'.</r:Content>
-            <r:Content>CMM_Mapping: None</r:Content>
-        </r:Description>
-        <pr:Instructions>
-            <r:Content>
-                <![CDATA[
-                <Constraints>
-                    <MandatoryNodeIfParentPresentConstraint/>
-                </Constraints>
-                ]]>
-            </r:Content>
-        </pr:Instructions>
-    </pr:Used>
-    <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
     <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">

--- a/CDC_2.5_PROFILE/cdc25_profile_mono.xml
+++ b/CDC_2.5_PROFILE/cdc25_profile_mono.xml
@@ -889,42 +889,6 @@ ________________________________________________________________________________
         </pr:Instructions>
     </pr:Used>
     <!--****************************************************************************************-->
-    <!--ACCESS CATEGORY - OPEN OR RESTRICTED-->
-    <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions" isRequired="true">
-        <r:Description>
-            <r:Content>Required: Mandatory</r:Content>
-            <r:Content>ElementType: Content element</r:Content>
-            <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: Controlled description of the data access (open access vs. restricted access).
-                CDC will use the same Access Rights vocabulary as OpenAIRE.
-                The name of the vocabulary is “info:eu-repo-Access-Terms vocabulary” - see
-                http://purl.org/eu-repo/semantics/#info-eu-repo-AccessRights
-                Only the codes “restrictedAccess” and “openAccess” will be used.</r:Content>
-            <r:Content>CDC_UI_Label: Open/Closed</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-    </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/conditions/@elementVersion"
-        defaultValue="info:eu-repo-Access-Terms vocabulary" fixedValue="true" isRequired="false">
-        <r:Description>
-            <r:Content>Required: Mandatory if 'conditions' element is present</r:Content>
-            <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Always 'info:eu-repo-Access-Terms vocabulary'.</r:Content>
-            <r:Content>CMM_Mapping: None</r:Content>
-        </r:Description>
-        <pr:Instructions>
-            <r:Content>
-                <![CDATA[
-                <Constraints>
-                    <MandatoryNodeIfParentPresentConstraint/>
-                </Constraints>
-                ]]>
-            </r:Content>
-        </pr:Instructions>
-    </pr:Used>
-
-    <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
     <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">

--- a/CDC_2.6_PROFILE/cdc26_profile.xml
+++ b/CDC_2.6_PROFILE/cdc26_profile.xml
@@ -1163,41 +1163,6 @@ ________________________________________________________________________________
         </pr:Instructions>
     </pr:Used>
     <!--****************************************************************************************-->
-    <!--ACCESS CATEGORY - OPEN OR RESTRICTED-->
-    <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/typeOfAccess" isRequired="true">
-        <r:Description>
-            <r:Content>Required: Mandatory</r:Content>
-            <r:Content>ElementType: Content element</r:Content>
-            <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: Controlled description of the data access (open access vs. restricted access).
-                CDC will use the same Access Rights vocabulary as OpenAIRE. 
-                The name of the vocabulary is “info:eu-repo-Access-Terms vocabulary” - see
-                http://purl.org/eu-repo/semantics/#info-eu-repo-AccessRights
-                Only the codes “restrictedAccess” and “openAccess” will be used.</r:Content>
-            <r:Content>CDC_UI_Label: Open/Closed</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-    </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/typeOfAccess/@vocabURI" 
-        defaultValue="info:eu-repo-Access-Terms vocabulary" fixedValue="true" isRequired="false">
-        <r:Description>
-            <r:Content>Required: Mandatory if '../typeofAccess' element is present</r:Content>
-            <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Always 'info:eu-repo-Access-Terms vocabulary'.</r:Content>
-            <r:Content>CMM_Mapping: None</r:Content>
-        </r:Description>
-        <pr:Instructions>
-            <r:Content>
-                <![CDATA[
-                <Constraints>
-                    <MandatoryNodeIfParentPresentConstraint/>
-                </Constraints>
-                ]]>
-            </r:Content>
-        </pr:Instructions>
-    </pr:Used>
-    <!--****************************************************************************************-->
     <!--ACCESS STATEMENT-->
     <!--****************************************************************************************-->
     <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">

--- a/CDC_2.6_PROFILE/cdc26_profile_mono.xml
+++ b/CDC_2.6_PROFILE/cdc26_profile_mono.xml
@@ -867,41 +867,6 @@ ________________________________________________________________________________
         </pr:Instructions>
     </pr:Used>
     <!--****************************************************************************************-->
-    <!--ACCESS CATEGORY - OPEN OR RESTRICTED-->
-    <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/typeOfAccess" isRequired="true">
-        <r:Description>
-            <r:Content>Required: Mandatory</r:Content>
-            <r:Content>ElementType: Content element</r:Content>
-            <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: Controlled description of the data access (open access vs. restricted access).
-                CDC will use the same Access Rights vocabulary as OpenAIRE. 
-                The name of the vocabulary is “info:eu-repo-Access-Terms vocabulary” - see
-                http://purl.org/eu-repo/semantics/#info-eu-repo-AccessRights
-                Only the codes “restrictedAccess” and “openAccess” will be used.</r:Content>
-            <r:Content>CDC_UI_Label: Open/Closed</r:Content>
-            <r:Content>CMM_Mapping: 1.4.1</r:Content>
-        </r:Description>
-    </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/typeOfAccess/@vocabURI" 
-        defaultValue="info:eu-repo-Access-Terms vocabulary" fixedValue="true" isRequired="false">
-        <r:Description>
-            <r:Content>Required: Mandatory if '../typeofAccess' element is present</r:Content>
-            <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Always 'info:eu-repo-Access-Terms vocabulary'.</r:Content>
-            <r:Content>CMM_Mapping: None</r:Content>
-        </r:Description>
-        <pr:Instructions>
-            <r:Content>
-                <![CDATA[
-                <Constraints>
-                    <MandatoryNodeIfParentPresentConstraint/>
-                </Constraints>
-                ]]>
-            </r:Content>
-        </pr:Instructions>
-    </pr:Used>
-    <!--****************************************************************************************-->
     <!--ACCESS STATEMENT-->
     <!--****************************************************************************************-->
     <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">


### PR DESCRIPTION
Only DDI-C 1.2.2 and DDI-C 2.5 profiles are changed; /codeBook/stdyDscr/dataAccs/useStmt/conditions and /codeBook/stdyDscr/dataAccs/useStmt/conditions/@elementVersion not appearing in DDI-C 2.6 profiles